### PR TITLE
Zds 430/bugticket grid column padding has wrong format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeppelin-element-library",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Zeppelin Elements Library is an element library for digital Zeppelin products.",
   "main": "bundle/zeppelin-element-library.cjs.js",
   "module": "bundle/zeppelin-element-library.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeppelin-element-library",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Zeppelin Elements Library is an element library for digital Zeppelin products.",
   "main": "bundle/zeppelin-element-library.cjs.js",
   "module": "bundle/zeppelin-element-library.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeppelin-element-library",
-  "version": "0.7.0",
+  "version": "0.7.4",
   "description": "Zeppelin Elements Library is an element library for digital Zeppelin products.",
   "main": "bundle/zeppelin-element-library.cjs.js",
   "module": "bundle/zeppelin-element-library.esm.js",
@@ -21,6 +21,7 @@
     "commit": "git-cz",
     "semantic-release": "semantic-release",
     "prettier": "prettier src/**/*.js src/**/*.jsx",
+    "publish:check": "semantic-release --branch development --no-ci --dry-run",
     "publish:dev": "yarn publish --tag=next",
     "sonar-scanner": "sonar-scanner",
     "lint:eslint": "eslint src/**/*.js src/**/*.jsx",

--- a/src/guidelines/_grid.scss
+++ b/src/guidelines/_grid.scss
@@ -184,7 +184,8 @@ $grid-max-width: #{map-get($min-screensize-map, l)}px;
   // clear grid-gutter on the first/left and last/right elements
   @each $screensize, $valuelist in $grid-values-map {
     @include breakpoint--min(#{$screensize}) {
-      $grid-gutter: nth($valuelist, 3);
+      // TODO: get grid-gutter from map if castToSass problem is fixed
+      $grid-gutter: 32px; //nth($valuelist, 3);
       $half-grid-gutter: $grid-gutter / 2;
 
       // use negative margin to clear grid-gutter

--- a/src/guidelines/_grid.scss
+++ b/src/guidelines/_grid.scss
@@ -12,6 +12,7 @@
 
 // values: colums, margin, grid-gutter
 // TODO: Fix castToSass() columns output as number
+// grid gutter is currently not used from map.
 $grid-values-map: (
   xs: (
     6,
@@ -258,7 +259,8 @@ $grid-gutter: 24px;
 // set cols for xs - xl
 @each $screensize, $valuelist in $grid-values-map {
   $cols: nth($valuelist, 1);
-  $grid-gutter: nth($valuelist, 3);
+  // TODO: get grid-gutter from map if castToSass problem is fixed
+  $grid-gutter: 32px; //nth($valuelist, 3);
 
   @for $i from 1 through $cols {
     .#{$prefix}grid__col--#{$screensize}-#{$i}-#{$cols} {


### PR DESCRIPTION
closes ZDS-430 Bugticket.
Solution is a workaround until we have a better way to connect SCSS and theme.json data.